### PR TITLE
Feature/intersphinx basic auth

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ Other contributors, listed alphabetically, are:
 * John Waltman -- Texinfo builder
 * Barry Warsaw -- setup command improvements
 * Sebastian Wiesner -- image handling, distutils support
+* Michael Wilson -- Intersphinx HTTP basic auth support
 * Joel Wurtz -- cellspanning support in LaTeX
 
 Many thanks for all contributions!

--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,8 @@ Features added
 * C++ type alias support (e.g., ``.. type:: T = int``)
 * C++ template support for classes, functions, type aliases, and variables (#1729, #1314).
 * C++, added new scope management directives ``namespace-push`` and ``namespace-pop``.
+* Intersphinx: Added support for fetching Intersphinx inventories with URLs
+  using HTTP basic auth
 
 Bugs fixed
 ----------

--- a/tests/test_ext_intersphinx.py
+++ b/tests/test_ext_intersphinx.py
@@ -9,17 +9,19 @@
     :license: BSD, see LICENSE for details.
 """
 
-import zlib
 import posixpath
+import unittest
+import zlib
 
 from six import BytesIO
 from docutils import nodes
 
 from sphinx import addnodes
 from sphinx.ext.intersphinx import read_inventory_v1, read_inventory_v2, \
-    load_mappings, missing_reference
+    load_mappings, missing_reference, _strip_basic_auth, _read_from_url, \
+    _get_safe_url
 
-from util import with_app, with_tempdir
+from util import with_app, with_tempdir, mock
 
 
 inventory_v1 = '''\
@@ -175,3 +177,77 @@ def test_load_mappings_warnings(tempdir, app, status, warning):
     # load the inventory and check if it's done correctly
     load_mappings(app)
     assert warning.getvalue().count('\n') == 2
+
+
+class TestStripBasicAuth(unittest.TestCase):
+    """Tests for sphinx.ext.intersphinx._strip_basic_auth()"""
+    def test_auth_stripped(self):
+        """basic auth creds stripped from URL containing creds"""
+        url = 'https://user:12345@domain.com/project/objects.inv'
+        expected = 'https://domain.com/project/objects.inv'
+        actual_url, actual_username, actual_password = _strip_basic_auth(url)
+        self.assertEqual(expected, actual_url)
+        self.assertEqual('user', actual_username)
+        self.assertEqual('12345', actual_password)
+
+    def test_no_auth(self):
+        """url unchanged if param doesn't contain basic auth creds"""
+        url = 'https://domain.com/project/objects.inv'
+        expected = 'https://domain.com/project/objects.inv'
+        actual_url, actual_username, actual_password = _strip_basic_auth(url)
+        self.assertEqual(expected, actual_url)
+        self.assertEqual(None, actual_username)
+        self.assertEqual(None, actual_password)
+
+
+class TestReadFromUrl(unittest.TestCase):
+    """Tests for sphinx.ext.intersphinx._read_from_url()"""
+    @mock.patch('six.moves.urllib.request.HTTPBasicAuthHandler')
+    @mock.patch('six.moves.urllib.request.HTTPPasswordMgrWithDefaultRealm')
+    @mock.patch('six.moves.urllib.request.build_opener')
+    def test_authed(self, m_build_opener, m_HTTPPasswordMgrWithDefaultRealm,
+                    m_HTTPBasicAuthHandler):
+        """read from URL containing basic auth creds"""
+        password_mgr = mock.Mock()
+        m_HTTPPasswordMgrWithDefaultRealm.return_value = password_mgr
+
+        url = 'https://user:12345@domain.com/project/objects.inv'
+        _read_from_url(url)
+
+        m_HTTPPasswordMgrWithDefaultRealm.assert_called_once_with()
+        password_mgr.add_password.assert_called_with(
+            None, 'https://domain.com/project/objects.inv', 'user', '12345')
+
+    @mock.patch('six.moves.urllib.request.HTTPBasicAuthHandler')
+    @mock.patch('six.moves.urllib.request.HTTPPasswordMgrWithDefaultRealm')
+    @mock.patch('six.moves.urllib.request.build_opener')
+    def test_unauthed(self, m_build_opener, m_HTTPPasswordMgrWithDefaultRealm,
+                    m_HTTPBasicAuthHandler):
+        """read from URL without auth creds"""
+        password_mgr = mock.Mock()
+        m_HTTPPasswordMgrWithDefaultRealm.return_value = password_mgr
+
+        url = 'https://domain.com/project/objects.inv'
+        _read_from_url(url)
+
+        # assert password manager not created
+        self.assertEqual(None, m_HTTPPasswordMgrWithDefaultRealm.call_args)
+        # assert no password added to the password manager
+        self.assertEqual(None, password_mgr.add_password.call_args)
+
+
+class TestGetSafeUrl(unittest.TestCase):
+    """Tests for sphinx.ext.intersphinx._get_safe_url()"""
+    def test_authed(self):
+        """_get_safe_url() with a url with basic auth"""
+        url = 'https://user:12345@domain.com/project/objects.inv'
+        expected = 'https://user:********@domain.com/project/objects.inv'
+        actual = _get_safe_url(url)
+        self.assertEqual(expected, actual)
+
+    def test_unauthed(self):
+        """_get_safe_url() with a url without basic auth"""
+        url = 'https://domain.com/project/objects.inv'
+        expected = 'https://domain.com/project/objects.inv'
+        actual = _get_safe_url(url)
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
This PR sees an enhancement to the Intersphinx feature of the Sphinx documentation project.

It is now possible for intersphinx mappings to list HTTP URLs which include basic auth credentials. This enables documentation authors to specify external documentation projects which sit behind HTP basic auth. This feature was implemented without the addition of any third-party libraries. 
